### PR TITLE
Adds a way to auto roll MidiQOL Choose Effects and apply the corresponding one.

### DIFF
--- a/scripts/bugs-main.mjs
+++ b/scripts/bugs-main.mjs
@@ -504,6 +504,8 @@ Hooks.once('midi-qol.ready', () => {
 async function implementAutoMidiChooseEffects(app, html, data) {
 	if (!getAutomateChooseEffects() || !html.hasClass('effectNoTarget')) return;
 	const buttons = html.find('button');
+	const item = fromUuidSync(Object.keys(data.buttons)[0].split('.ActiveEffect')[0]);
+	if (!item?.system.requirements?.includes('[auto]')) return;
 	const numButtons = buttons.length;
 
 	if (numButtons === 0) return;

--- a/scripts/bugs-main.mjs
+++ b/scripts/bugs-main.mjs
@@ -1,6 +1,6 @@
 const MODULE_ID = 'bugs';
 
-let modernRules;
+let modernRules, midiVersion;
 
 function initializeStatusEffects() {
 	const statusEffects = {};
@@ -479,7 +479,6 @@ Hooks.once('midi-qol.ready', () => {
 			}
 		});
 		Hooks.on('preCreateActiveEffect', (ae, aedata) => {
-			console.log('BUGS,', ae);
 			if (ae.parent instanceof CONFIG.Item.documentClass) return true;
 			if (shouldProceed(aedata, 'create')) {
 				const changes = getChanges(ae);
@@ -498,6 +497,8 @@ Hooks.once('midi-qol.ready', () => {
 			}
 		});
 	}
+	midiVersion = game.modules.get('midi-qol').version;
+	if (foundry.utils.isNewerVersion(midiVersion, '12.4.31')) Hooks.on('renderDialog', implementAutoMidiChooseEffects);
 	globalThis.BUGS = BUGS;
 });
 
@@ -536,7 +537,7 @@ function registerSettings() {
 	});
 	game.settings.register('bugs', 'automateChooseEffects', {
 		name: 'Automatically roll for MidiQOL choose effects',
-		hint: 'Handles automatically selecting one of the MidiQOL Choose effects options and applying it. To use, in the Item`s requirements field, type: [auto]',
+		hint: 'Handles automatically selecting one of the MidiQOL (12.4.32+) Choose effects options and applying it. To use, in the Item`s requirements field, type: [auto]',
 		scope: 'world',
 		config: true,
 		default: true,
@@ -553,5 +554,4 @@ function getAutomateChooseEffects() {
 }
 
 //other Hooks
-Hooks.on('renderDialog', implementAutoMidiChooseEffects);
-Hooks.on('init', registerSettings);
+Hooks.once('init', registerSettings);

--- a/scripts/bugs-main.mjs
+++ b/scripts/bugs-main.mjs
@@ -506,7 +506,7 @@ async function implementAutoMidiChooseEffects(app, html, data) {
 	if (!getAutomateChooseEffects() || !html.hasClass('effectNoTarget')) return;
 	const buttons = html.find('button');
 	const item = fromUuidSync(Object.keys(data.buttons)[0].split('.ActiveEffect')[0]);
-	if (!item?.system.requirements?.includes('[auto]')) return;
+	if (!item?.system.requirements?.includes('[autoMidiChooseEffects]')) return;
 	const numButtons = buttons.length;
 
 	if (numButtons === 0) return;


### PR DESCRIPTION
To trigger this function, add in the Item's requirements field: `[autoMidiChooseEffects]`

![image](https://github.com/user-attachments/assets/c07beb35-acbe-40ca-b739-d4c47fe338ee)

[chooseEffectsAuto.webm](https://github.com/user-attachments/assets/df83efb4-2187-4919-99b1-f875dbf5d626)
